### PR TITLE
Add possibility of filtering tools

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -23,8 +23,8 @@ hash -r
 conda info -a
 
 # Generate the tests
-make generate-tests
-make info
+make $@ generate-tests
+make $@ info
 
 set +e
 set +x

--- a/.github/workflows/run.sh
+++ b/.github/workflows/run.sh
@@ -7,5 +7,5 @@ conda activate sv-test-env
 hash -r
 set -x
 
-make info
-make -j2
+make $@ info
+make $@

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -47,8 +47,8 @@ jobs:
           - { JOB_NAME: antmicro-yosys-complete, MAKEFLAGS: -j2 }
           - { JOB_NAME: verible, MAKEFLAGS: -j2 }
           - { JOB_NAME: verilator, MAKEFLAGS: -j2 }
-          - { JOB_NAME: uhdm-integration-verilator, MAKEFLAGS: -j2 }
-          - { JOB_NAME: uhdm-integration-yosys, MAKEFLAGS: -j2 }
+          - { JOB_NAME: uhdm-integration-verilator, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmVerilator }
+          - { JOB_NAME: uhdm-integration-yosys, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmYosys }
           - { JOB_NAME: zachjs-sv2v, MAKEFLAGS: -j2 }
 
     name: ${{ matrix.env.JOB_NAME }}
@@ -62,10 +62,10 @@ jobs:
           python-version: 3.7
       - name: Install
         run:
-          ./.github/workflows/install.sh
+          ./.github/workflows/install.sh ${{ matrix.env.MAKEFLAGS }}
       - name: Run
         run:
-          ./.github/workflows/run.sh
+          ./.github/workflows/run.sh ${{ matrix.env.MAKEFLAGS }}
       - name: Prepare Report
         run:
           ./.github/workflows/tool_report_prepare.sh

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,12 @@ endef
 RUNNERS_FOUND := $(wildcard $(RUNNERS_DIR)/*.py)
 RUNNERS_FOUND := $(RUNNERS_FOUND:$(RUNNERS_DIR)/%=%)
 RUNNERS_FOUND := $(basename $(RUNNERS_FOUND))
-RUNNERS := $(shell OUT_DIR=$(OUT_DIR) RUNNERS_DIR=$(RUNNERS_DIR) ./tools/check-runners $(RUNNERS_FOUND))
+
+ifdef RUNNERS_FILTER
+FILTER := --filter $(RUNNERS_FILTER)
+endif
+
+RUNNERS := $(shell OUT_DIR=$(OUT_DIR) RUNNERS_DIR=$(RUNNERS_DIR) ./tools/check-runners $(RUNNERS_FOUND) $(FILTER))
 TESTS := $(shell find $(TESTS_DIR) -type f -iname *.sv)
 TESTS := $(TESTS:$(TESTS_DIR)/%=%)
 GENERATORS := $(wildcard $(GENERATORS_DIR)/*)

--- a/tools/check-runners
+++ b/tools/check-runners
@@ -19,6 +19,7 @@ from importlib import import_module
 parser = argparse.ArgumentParser()
 
 parser.add_argument("runners", metavar='runner', type=str, nargs='+')
+parser.add_argument("--filter", type=str, nargs='*')
 
 args = parser.parse_args()
 logger = logging.getLogger()
@@ -30,7 +31,14 @@ runners_ok = []
 if 'RUNNERS_DIR' in os.environ:
     sys.path.insert(1, os.path.abspath(os.environ['RUNNERS_DIR']))
 
-for runner in args.runners:
+if args.filter is not None:
+    runners = set(args.runners) & set(args.filter)
+else:
+    runners = set(args.runners)
+
+runners = list(sorted(runners))
+
+for runner in runners:
     try:
         module = import_module(runner)
         runner_cls = getattr(module, runner)


### PR DESCRIPTION
Some runners are dependent to other runners, so they have to be installed. Now they are tested in these jobs and in their own jobs too, which results in duplication of tests results.
E.g.:
uhdm-yosys uses surelog as frontend and sv-tests are detecting it as separate tool and are running it one more time. 

I fix it by adding possibility to filter tools in Makefile and run tests only on selected runners. I also add usage of MAKEFLAGS field in sv-tests-ci.yml.